### PR TITLE
Some warnings appearing in Xcode 4

### DIFF
--- a/XMLRPCConnection.m
+++ b/XMLRPCConnection.m
@@ -51,7 +51,8 @@
 @implementation XMLRPCConnection
 
 - (id)initWithXMLRPCRequest: (XMLRPCRequest *)request delegate: (id<XMLRPCConnectionDelegate>)delegate manager: (XMLRPCConnectionManager *)manager {
-    if (self = [super init]) {
+    self = [super init];
+    if (self) {
         myManager = [manager retain];
         myRequest = [request retain];
         myIdentifier = [[NSString stringByGeneratingUUID] retain];

--- a/XMLRPCConnectionManager.m
+++ b/XMLRPCConnectionManager.m
@@ -29,7 +29,8 @@
 static XMLRPCConnectionManager *sharedInstance = nil;
 
 - (id)init {
-    if (self = [super init]) {
+    self = [super init];
+    if (self) {
         myConnections = [[NSMutableDictionary alloc] init];
     }
     
@@ -55,7 +56,7 @@ static XMLRPCConnectionManager *sharedInstance = nil;
 + (XMLRPCConnectionManager *)sharedManager {
     @synchronized(self) {
         if (!sharedInstance) {
-            [[self alloc] init];
+            sharedInstance = [[self alloc] init];
         }
     }
     

--- a/XMLRPCEncoder.m
+++ b/XMLRPCEncoder.m
@@ -60,7 +60,8 @@
 @implementation XMLRPCEncoder
 
 - (id)init {
-    if (self = [super init]) {
+    self = [super init];
+    if (self) {
         myMethod = [[NSString alloc] init];
         myParameters = [[NSArray alloc] init];
     }
@@ -81,7 +82,7 @@
         NSEnumerator *enumerator = [myParameters objectEnumerator];
         id parameter = nil;
         
-        while (parameter = [enumerator nextObject]) {
+        while ((parameter = [enumerator nextObject])) {
             [buffer appendString: @"<param>"];
             [buffer appendString: [self encodeObject: parameter]];
             [buffer appendString: @"</param>"];

--- a/XMLRPCEventBasedParserDelegate.m
+++ b/XMLRPCEventBasedParserDelegate.m
@@ -56,7 +56,8 @@
 @implementation XMLRPCEventBasedParserDelegate
 
 - (id)initWithParent: (XMLRPCEventBasedParserDelegate *)parent {
-    if (self = [super init]) {
+    self = [super init];
+    if (self) {
         myParent = parent;
         myChildren = [[NSMutableArray alloc] initWithCapacity: 1];
         myElementType = XMLRPCElementTypeString;

--- a/XMLRPCRequest.m
+++ b/XMLRPCRequest.m
@@ -26,7 +26,8 @@
 @implementation XMLRPCRequest
 
 - (id)initWithURL: (NSURL *)URL {
-    if (self = [super init]) {
+    self = [super init];
+    if (self) {
         if (URL) {
             myRequest = [[NSMutableURLRequest alloc] initWithURL: URL];
         } else {

--- a/XMLRPCResponse.m
+++ b/XMLRPCResponse.m
@@ -30,7 +30,8 @@
         return nil;
     }
 
-    if (self = [super init]) {
+    self = [super init];
+    if (self) {
         XMLRPCEventBasedParser *parser = [[XMLRPCEventBasedParser alloc] initWithData: data];
         
         if (!parser) {


### PR DESCRIPTION
I fixed a few warnings that appear in Xcode 4. Mainly self = [super init]; if(self) {... instead of if(self=[super init]) {...
