### PR TITLE
HTTP header improvements

### DIFF
--- a/XMLRPCRequest.h
+++ b/XMLRPCRequest.h
@@ -65,4 +65,8 @@
 
 - (NSURLRequest *)request;
 
+#pragma mark -
+
+- (void)setValue:(NSString *)value forHTTPHeaderField:(NSString *)header;
+
 @end

--- a/XMLRPCRequest.m
+++ b/XMLRPCRequest.m
@@ -129,6 +129,13 @@
     return (NSURLRequest *)myRequest;
 }
 
+- (void)setValue:(NSString *)value forHTTPHeaderField:(NSString *)header {
+    [myRequest setValue:value forHTTPHeaderField:header];
+}
+
+
+#pragma mark -
+
 #pragma mark -
 
 - (void)dealloc {

--- a/XMLRPCRequest.m
+++ b/XMLRPCRequest.m
@@ -124,6 +124,12 @@
         [myRequest setValue: [contentLength stringValue] forHTTPHeaderField: @"Content-Length"];
     }
     
+    if (![myRequest valueForHTTPHeaderField: @"Accept"]) {
+        [myRequest addValue: @"text/xml" forHTTPHeaderField: @"Accept"];
+    } else {
+        [myRequest setValue: @"text/xml" forHTTPHeaderField: @"Accept"];
+    }
+    
     if (![self userAgent]) {
       NSString *userAgent = [[NSUserDefaults standardUserDefaults] objectForKey:@"UserAgent"];
       if (userAgent) {

--- a/XMLRPCRequest.m
+++ b/XMLRPCRequest.m
@@ -124,6 +124,13 @@
         [myRequest setValue: [contentLength stringValue] forHTTPHeaderField: @"Content-Length"];
     }
     
+    if (![self userAgent]) {
+      NSString *userAgent = [[NSUserDefaults standardUserDefaults] objectForKey:@"UserAgent"];
+      if (userAgent) {
+        [self setUserAgent:userAgent];
+      }
+    }
+    
     [myRequest setHTTPBody: content];
     
     return (NSURLRequest *)myRequest;


### PR DESCRIPTION
Hey, I've added a few improvements to XMLRPCResponse headers:
- Get User Agent from NSUserDefaults if none is specified (same as UIWebView)
- Added Accept header, required for some hosts using mod_security ([see issue for reference](http://ios.trac.wordpress.org/ticket/898))
- Added support for custom HTTP headers
