### PR TITLE
Implement support for user specified xml encoders.

### DIFF
--- a/XMLRPC.xcodeproj/project.pbxproj
+++ b/XMLRPC.xcodeproj/project.pbxproj
@@ -30,8 +30,8 @@
 		07B0C6090E33A659006453B4 /* XMLRPC.h in Headers */ = {isa = PBXBuildFile; fileRef = 07B0C5FA0E33A659006453B4 /* XMLRPC.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		07B0C60A0E33A659006453B4 /* XMLRPCConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 07B0C5FB0E33A659006453B4 /* XMLRPCConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		07B0C60B0E33A659006453B4 /* XMLRPCConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 07B0C5FC0E33A659006453B4 /* XMLRPCConnection.m */; };
-		07B0C60E0E33A659006453B4 /* XMLRPCEncoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 07B0C5FF0E33A659006453B4 /* XMLRPCEncoder.h */; };
-		07B0C60F0E33A659006453B4 /* XMLRPCEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 07B0C6000E33A659006453B4 /* XMLRPCEncoder.m */; };
+		07B0C60E0E33A659006453B4 /* XMLRPCDefaultEncoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 07B0C5FF0E33A659006453B4 /* XMLRPCDefaultEncoder.h */; };
+		07B0C60F0E33A659006453B4 /* XMLRPCDefaultEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 07B0C6000E33A659006453B4 /* XMLRPCDefaultEncoder.m */; };
 		07B0C6100E33A659006453B4 /* XMLRPCRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 07B0C6010E33A659006453B4 /* XMLRPCRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		07B0C6110E33A659006453B4 /* XMLRPCRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 07B0C6020E33A659006453B4 /* XMLRPCRequest.m */; };
 		07B0C6120E33A659006453B4 /* XMLRPCResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 07B0C6030E33A659006453B4 /* XMLRPCResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -45,6 +45,7 @@
 		07E761001011788B00E9BDEE /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7B1FEA5585E11CA2CBB /* Cocoa.framework */; };
 		07EF453B0E721A5D009F2708 /* XMLRPCEventBasedParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 07EF45390E721A5D009F2708 /* XMLRPCEventBasedParser.h */; };
 		07EF453C0E721A5D009F2708 /* XMLRPCEventBasedParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 07EF453A0E721A5D009F2708 /* XMLRPCEventBasedParser.m */; };
+		2DCADEDB1529E24300B47A4F /* XMLRPCEncoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DCADED91529E06900B47A4F /* XMLRPCEncoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8DC2EF570486A6940098B216 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7B1FEA5585E11CA2CBB /* Cocoa.framework */; };
 		903B0DC212F7581200BD6E09 /* NSStringAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 07B0C5F80E33A659006453B4 /* NSStringAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		903B0DC312F7581200BD6E09 /* NSStringAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 07B0C5F90E33A659006453B4 /* NSStringAdditions.m */; };
@@ -54,8 +55,8 @@
 		903B0DC712F7581200BD6E09 /* XMLRPCConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 07B0C5FC0E33A659006453B4 /* XMLRPCConnection.m */; };
 		903B0DC812F7581200BD6E09 /* XMLRPCConnectionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 075137F90E429E560019E4F6 /* XMLRPCConnectionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		903B0DC912F7581200BD6E09 /* XMLRPCConnectionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 075137FA0E429E560019E4F6 /* XMLRPCConnectionManager.m */; };
-		903B0DCA12F7581200BD6E09 /* XMLRPCEncoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 07B0C5FF0E33A659006453B4 /* XMLRPCEncoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		903B0DCB12F7581200BD6E09 /* XMLRPCEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 07B0C6000E33A659006453B4 /* XMLRPCEncoder.m */; };
+		903B0DCA12F7581200BD6E09 /* XMLRPCDefaultEncoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 07B0C5FF0E33A659006453B4 /* XMLRPCDefaultEncoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		903B0DCB12F7581200BD6E09 /* XMLRPCDefaultEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 07B0C6000E33A659006453B4 /* XMLRPCDefaultEncoder.m */; };
 		903B0DCC12F7581200BD6E09 /* XMLRPCEventBasedParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 07EF45390E721A5D009F2708 /* XMLRPCEventBasedParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		903B0DCD12F7581200BD6E09 /* XMLRPCEventBasedParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 07EF453A0E721A5D009F2708 /* XMLRPCEventBasedParser.m */; };
 		903B0DCE12F7581200BD6E09 /* XMLRPCEventBasedParserDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 0707047610114B9400CB7702 /* XMLRPCEventBasedParserDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -110,8 +111,8 @@
 		07B0C5FA0E33A659006453B4 /* XMLRPC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMLRPC.h; sourceTree = "<group>"; };
 		07B0C5FB0E33A659006453B4 /* XMLRPCConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMLRPCConnection.h; sourceTree = "<group>"; };
 		07B0C5FC0E33A659006453B4 /* XMLRPCConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMLRPCConnection.m; sourceTree = "<group>"; };
-		07B0C5FF0E33A659006453B4 /* XMLRPCEncoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMLRPCEncoder.h; sourceTree = "<group>"; };
-		07B0C6000E33A659006453B4 /* XMLRPCEncoder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMLRPCEncoder.m; sourceTree = "<group>"; };
+		07B0C5FF0E33A659006453B4 /* XMLRPCDefaultEncoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMLRPCDefaultEncoder.h; sourceTree = "<group>"; };
+		07B0C6000E33A659006453B4 /* XMLRPCDefaultEncoder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMLRPCDefaultEncoder.m; sourceTree = "<group>"; };
 		07B0C6010E33A659006453B4 /* XMLRPCRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMLRPCRequest.h; sourceTree = "<group>"; };
 		07B0C6020E33A659006453B4 /* XMLRPCRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMLRPCRequest.m; sourceTree = "<group>"; };
 		07B0C6030E33A659006453B4 /* XMLRPCResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMLRPCResponse.h; sourceTree = "<group>"; };
@@ -128,6 +129,7 @@
 		0867D69BFE84028FC02AAC07 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
 		0867D6A5FE840307C02AAC07 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		1058C7B1FEA5585E11CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
+		2DCADED91529E06900B47A4F /* XMLRPCEncoder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XMLRPCEncoder.h; sourceTree = "<group>"; };
 		8DC2EF5B0486A6940098B216 /* XMLRPC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = XMLRPC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		903B0DB612F7574800BD6E09 /* libXMLRPC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libXMLRPC.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2F7E79907B2D74100F64583 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = /System/Library/Frameworks/CoreData.framework; sourceTree = "<absolute>"; };
@@ -292,8 +294,9 @@
 				07B0C5FC0E33A659006453B4 /* XMLRPCConnection.m */,
 				075137F90E429E560019E4F6 /* XMLRPCConnectionManager.h */,
 				075137FA0E429E560019E4F6 /* XMLRPCConnectionManager.m */,
-				07B0C5FF0E33A659006453B4 /* XMLRPCEncoder.h */,
-				07B0C6000E33A659006453B4 /* XMLRPCEncoder.m */,
+				2DCADED91529E06900B47A4F /* XMLRPCEncoder.h */,
+				07B0C5FF0E33A659006453B4 /* XMLRPCDefaultEncoder.h */,
+				07B0C6000E33A659006453B4 /* XMLRPCDefaultEncoder.m */,
 				07EF45390E721A5D009F2708 /* XMLRPCEventBasedParser.h */,
 				07EF453A0E721A5D009F2708 /* XMLRPCEventBasedParser.m */,
 				0707047610114B9400CB7702 /* XMLRPCEventBasedParserDelegate.h */,
@@ -347,7 +350,7 @@
 				07B0C60A0E33A659006453B4 /* XMLRPCConnection.h in Headers */,
 				07452BE30E469C9000A57686 /* XMLRPCConnectionDelegate.h in Headers */,
 				075137FB0E429E560019E4F6 /* XMLRPCConnectionManager.h in Headers */,
-				07B0C60E0E33A659006453B4 /* XMLRPCEncoder.h in Headers */,
+				07B0C60E0E33A659006453B4 /* XMLRPCDefaultEncoder.h in Headers */,
 				07EF453B0E721A5D009F2708 /* XMLRPCEventBasedParser.h in Headers */,
 				0707047810114B9400CB7702 /* XMLRPCEventBasedParserDelegate.h in Headers */,
 				07B0C6100E33A659006453B4 /* XMLRPCRequest.h in Headers */,
@@ -365,7 +368,8 @@
 				903B0DC512F7581200BD6E09 /* XMLRPC.h in Headers */,
 				903B0DC612F7581200BD6E09 /* XMLRPCConnection.h in Headers */,
 				903B0DC812F7581200BD6E09 /* XMLRPCConnectionManager.h in Headers */,
-				903B0DCA12F7581200BD6E09 /* XMLRPCEncoder.h in Headers */,
+				2DCADEDB1529E24300B47A4F /* XMLRPCEncoder.h in Headers */,
+				903B0DCA12F7581200BD6E09 /* XMLRPCDefaultEncoder.h in Headers */,
 				903B0DCC12F7581200BD6E09 /* XMLRPCEventBasedParser.h in Headers */,
 				903B0DCE12F7581200BD6E09 /* XMLRPCEventBasedParserDelegate.h in Headers */,
 				903B0DD012F7581200BD6E09 /* XMLRPCRequest.h in Headers */,
@@ -553,7 +557,7 @@
 				07B0C6080E33A659006453B4 /* NSStringAdditions.m in Sources */,
 				07B0C60B0E33A659006453B4 /* XMLRPCConnection.m in Sources */,
 				075137FC0E429E560019E4F6 /* XMLRPCConnectionManager.m in Sources */,
-				07B0C60F0E33A659006453B4 /* XMLRPCEncoder.m in Sources */,
+				07B0C60F0E33A659006453B4 /* XMLRPCDefaultEncoder.m in Sources */,
 				07EF453C0E721A5D009F2708 /* XMLRPCEventBasedParser.m in Sources */,
 				0707047910114B9400CB7702 /* XMLRPCEventBasedParserDelegate.m in Sources */,
 				07B0C6110E33A659006453B4 /* XMLRPCRequest.m in Sources */,
@@ -569,7 +573,7 @@
 				903B0DC312F7581200BD6E09 /* NSStringAdditions.m in Sources */,
 				903B0DC712F7581200BD6E09 /* XMLRPCConnection.m in Sources */,
 				903B0DC912F7581200BD6E09 /* XMLRPCConnectionManager.m in Sources */,
-				903B0DCB12F7581200BD6E09 /* XMLRPCEncoder.m in Sources */,
+				903B0DCB12F7581200BD6E09 /* XMLRPCDefaultEncoder.m in Sources */,
 				903B0DCD12F7581200BD6E09 /* XMLRPCEventBasedParser.m in Sources */,
 				903B0DCF12F7581200BD6E09 /* XMLRPCEventBasedParserDelegate.m in Sources */,
 				903B0DD112F7581200BD6E09 /* XMLRPCRequest.m in Sources */,

--- a/XMLRPCDefaultEncoder.h
+++ b/XMLRPCDefaultEncoder.h
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+#import "XMLRPCEncoder.h"
+
+@interface XMLRPCDefaultEncoder : NSObject <XMLRPCEncoder> {
+    NSString *myMethod;
+    NSArray *myParameters;
+}
+@end

--- a/XMLRPCDefaultEncoder.m
+++ b/XMLRPCDefaultEncoder.m
@@ -1,8 +1,8 @@
-#import "XMLRPCEncoder.h"
+#import "XMLRPCDefaultEncoder.h"
 #import "NSStringAdditions.h"
 #import "NSData+Base64.h"
 
-@interface XMLRPCEncoder (XMLRPCEncoderPrivate)
+@interface XMLRPCDefaultEncoder (XMLRPCEncoderPrivate)
 
 - (NSString *)valueTag: (NSString *)tag value: (NSString *)value;
 
@@ -36,7 +36,7 @@
 
 #pragma mark -
 
-@implementation XMLRPCEncoder
+@implementation XMLRPCDefaultEncoder
 
 - (id)init {
     self = [super init];
@@ -122,7 +122,7 @@
 
 #pragma mark -
 
-@implementation XMLRPCEncoder (XMLRPCEncoderPrivate)
+@implementation XMLRPCDefaultEncoder (XMLRPCEncoderPrivate)
 
 - (NSString *)valueTag: (NSString *)tag value: (NSString *)value {
     return [NSString stringWithFormat: @"<value><%@>%@</%@></value>", tag, value, tag];

--- a/XMLRPCEncoder.h
+++ b/XMLRPCEncoder.h
@@ -1,16 +1,13 @@
 #import <Foundation/Foundation.h>
 
-@interface XMLRPCEncoder : NSObject {
-    NSString *myMethod;
-    NSArray *myParameters;
-}
-
+@protocol XMLRPCEncoder <NSObject>
 - (NSString *)encode;
 
 #pragma mark -
 
 - (void)setMethod: (NSString *)method withParameters: (NSArray *)parameters;
 
+- (void)setParameters: (NSArray*)parameters;
 #pragma mark -
 
 - (NSString *)method;

--- a/XMLRPCRequest.h
+++ b/XMLRPCRequest.h
@@ -1,10 +1,10 @@
 #import <Foundation/Foundation.h>
 
-@class XMLRPCEncoder;
+#import "XMlRPCEncoder.h"
 
 @interface XMLRPCRequest : NSObject {
     NSMutableURLRequest *myRequest;
-    XMLRPCEncoder *myXMLEncoder;
+    id<XMLRPCEncoder> myXMLEncoder;
 }
 
 - (id)initWithURL: (NSURL *)URL;
@@ -22,6 +22,7 @@
 - (NSString *)userAgent;
 
 #pragma mark -
+- (void)setEncoder: (id<XMLRPCEncoder>) encoder;
 
 - (void)setMethod: (NSString *)method;
 

--- a/XMLRPCRequest.m
+++ b/XMLRPCRequest.m
@@ -1,9 +1,10 @@
 #import "XMLRPCRequest.h"
 #import "XMLRPCEncoder.h"
+#import "XMLRPCDefaultEncoder.h"
 
 @implementation XMLRPCRequest
 
-- (id)initWithURL: (NSURL *)URL {
+- (id)initWithURL: (NSURL *)URL withEncoder: (id<XMLRPCEncoder>)encoder {
     self = [super init];
     if (self) {
         if (URL) {
@@ -12,10 +13,14 @@
             myRequest = [[NSMutableURLRequest alloc] init];
         }
         
-        myXMLEncoder = [[XMLRPCEncoder alloc] init];
+        myXMLEncoder = encoder;
     }
     
     return self;
+}
+
+- (id)initWithURL: (NSURL *)URL {
+    return [self initWithURL:URL withEncoder:[[XMLRPCDefaultEncoder alloc] init]];
 }
 
 #pragma mark -
@@ -43,6 +48,15 @@
 }
 
 #pragma mark -
+
+- (void)setEncoder:(id<XMLRPCEncoder>)encoder {
+    //Copy the old method and parameters to the new encoder.
+    NSString *method = [myXMLEncoder method];
+    NSArray *parameters = [myXMLEncoder parameters];
+    [myXMLEncoder release];
+    myXMLEncoder = [encoder retain];
+    [myXMLEncoder setMethod:method withParameters:parameters];
+}
 
 - (void)setMethod: (NSString *)method {
     [myXMLEncoder setMethod: method withParameters: nil];


### PR DESCRIPTION
This is a combination of 10 commits.
Refactor XMLRPCEncoder to XMLRPCEncoderImpl.

This change renames XMLRPCEncoder to XMLRPCEncoderImpl to imply that
XMLRPCEncoder is actually an implentation of a interface yet to be defined. The
yet to be defined interface will allow users of the xmlrpc to prvide theier own
encoders to support XMLRPC extensions.

Create a protocol for XMLRPCEncoderImpl to implement.

This protocol will be used instead of XMLRPCEncoderImpl directly.

Have XMLRPC Request use the new XMLRPCEncoder protocol instead of XMLRPCEncoderImpl

Add a setEncoder method.

Remove header created by XCode

Refactor XMLRPCDencoderImpl to XMLRPCDefaultEndcoder

This refactor was made in response to a discussion on naming conventions here:
https://github.com/eczarny/xmlrpc/pull/17#r645514

Remove unnecessary prototypes from XMLRPCDefaultEncoder

The methods in defined in XMLRPCDefaultEncoder.h are already defined in the
XMLRPCEncoder protocol and there are are redundant.

Add a constuctor to initialize XMLRPCRequest with a given encoder.

HAve XMLRPCREquest take ownership of encoders assigned to it.

This commit causes XMLRPCRequest to retain all XMLRPCEncoders assigned to it.

Call default constructor when initailizing the default XMLRPC Encoder
