### PR TITLE
Ignore invalid/null dates

### DIFF
--- a/XMLRPCEventBasedParserDelegate.m
+++ b/XMLRPCEventBasedParserDelegate.m
@@ -267,7 +267,11 @@
             
             break;
         case XMLRPCElementTypeDictionary:
-            [parentElementValue setObject: myElementValue forKey: myElementKey];
+            if ([myElementValue isEqual:[NSNull null]]) {
+                [parentElementValue removeObjectForKey:myElementKey];
+            } else {
+                [parentElementValue setObject: myElementValue forKey: myElementKey];
+            }
             
             break;
         case XMLRPCElementTypeMember:
@@ -329,6 +333,10 @@
         result = [self parseDateString: value withFormat: @"yyyy'-'MM'-'dd'T'HH:mm:ss"];
     }
     
+    if (!result) {
+        result = (NSDate *)[NSNull null];
+    }
+
     return result;
 }
 


### PR DESCRIPTION
When using invalid dates such as '00000000T00:00:00Z', the result of parseDate: is nil.
Instead of not storing a NULL value in the result, an empty string is stored

Sample XML:

```
<?xml version="1.0"?>
<methodResponse>
  <params>
    <param>
      <value>
      <array><data>
  <value><struct>
  <member><name>dateCreated</name><value><dateTime.iso8601>00000000T00:00:00Z</dateTime.iso8601></value></member>
  <member><name>userid</name><value><string>5</string></value></member>
</struct></value>
</data></array>
      </value>
    </param>
  </params>
</methodResponse>
```

Before the patch:

```
(
        {
        dateCreated = "";
        userid = 5;
    }
)
```

After the patch:

```
(
        {
        userid = 5;
    }
)
```
