### PR TITLE
Connection pointer available via request object

### DIFF
--- a/XMLRPCConnectionManager.m
+++ b/XMLRPCConnectionManager.m
@@ -49,6 +49,8 @@ static XMLRPCConnectionManager *sharedInstance = nil;
     
     [myConnections setObject: newConnection forKey: identifier];
     
+    [request setConnection:newConnection];
+    
     [newConnection release];
     
     return identifier;

--- a/XMLRPCRequest.h
+++ b/XMLRPCRequest.h
@@ -1,8 +1,10 @@
 #import <Foundation/Foundation.h>
 
 #import "XMlRPCEncoder.h"
+#import "XMLRPCConnection.h"
 
 @interface XMLRPCRequest : NSObject {
+    XMLRPCConnection *myConnection;
     NSMutableURLRequest *myRequest;
     id<XMLRPCEncoder> myXMLEncoder;
 }
@@ -43,6 +45,12 @@
 #pragma mark -
 
 - (NSURLRequest *)request;
+
+#pragma mark -
+
+- (void)setConnection:(XMLRPCConnection *)connection;
+
+- (XMLRPCConnection *)connection;
 
 #pragma mark -
 

--- a/XMLRPCRequest.m
+++ b/XMLRPCRequest.m
@@ -143,6 +143,7 @@
 #pragma mark -
 
 - (void)setConnection:(XMLRPCConnection *)connection {
+    [myConnection release];
     myConnection = connection;
     [myConnection retain];
 }

--- a/XMLRPCRequest.m
+++ b/XMLRPCRequest.m
@@ -142,9 +142,22 @@
 
 #pragma mark -
 
+- (void)setConnection:(XMLRPCConnection *)connection {
+    myConnection = connection;
+    [myConnection retain];
+}
+
+- (XMLRPCConnection *)connection {
+    return myConnection;
+}
+
+
+#pragma mark -
+
 - (void)dealloc {
     [myRequest release];
     [myXMLEncoder release];
+    [myConnection release];
     
     [super dealloc];
 }


### PR DESCRIPTION
Adds a pointer to the xmlrpc connection inside of the request itself,
this allows for the delegate response handler to access the connection
via

[request connection];

and more importantly the connection's uuid identifier via

[[request connection] identifier];

this allows for a single delegate class to dispatch responses uniquely
based on their uuid, essentially providing a direct mapping external to
the rpc client.

This patch also should not impact existing clients as it doesn't change
any delegate requirements, but simply passively exposes the connection
to those who desire it.
