### PR TITLE
Added ARC Support

### DIFF
--- a/NSData+Base64.m
+++ b/NSData+Base64.m
@@ -300,12 +300,12 @@ char *NewBase64Encode(
 	char *outputBuffer =
 		NewBase64Encode([self bytes], [self length], true, &outputLength);
 	
-	NSString *result =
-		[[[NSString alloc]
-			initWithBytes:outputBuffer
-			length:outputLength
-			encoding:NSASCIIStringEncoding]
-		autorelease];
+	NSString *result =[[NSString alloc] initWithBytes:outputBuffer
+											   length:outputLength
+											 encoding:NSASCIIStringEncoding];
+#if ! __has_feature(objc_arc)
+	[result autorelease];
+#endif
 	free(outputBuffer);
 	return result;
 }

--- a/NSStringAdditions.m
+++ b/NSStringAdditions.m
@@ -7,8 +7,11 @@
     CFStringRef temporaryUUIDString = CFUUIDCreateString(nil, UUIDReference);
     
     CFRelease(UUIDReference);
-    
+#if ! __has_feature(objc_arc)
     return [NSMakeCollectable(temporaryUUIDString) autorelease];
+#else
+    return (__bridge_transfer NSString*)temporaryUUIDString;
+#endif
 }
 
 #pragma mark -

--- a/XMLRPCConnectionManager.m
+++ b/XMLRPCConnectionManager.m
@@ -45,11 +45,17 @@ static XMLRPCConnectionManager *sharedInstance = nil;
 
 - (NSString *)spawnConnectionWithXMLRPCRequest: (XMLRPCRequest *)request delegate: (id<XMLRPCConnectionDelegate>)delegate {
     XMLRPCConnection *newConnection = [[XMLRPCConnection alloc] initWithXMLRPCRequest: request delegate: delegate manager: self];
+#if ! __has_feature(objc_arc)
     NSString *identifier = [[[newConnection identifier] retain] autorelease];
+#else
+    NSString *identifier = [newConnection identifier];
+#endif
     
     [myConnections setObject: newConnection forKey: identifier];
     
+#if ! __has_feature(objc_arc)
     [newConnection release];
+#endif
     
     return identifier;
 }
@@ -100,10 +106,10 @@ static XMLRPCConnectionManager *sharedInstance = nil;
 
 - (void)dealloc {
     [self closeConnections];
-    
+#if ! __has_feature(objc_arc)
     [myConnections release];
-    
     [super dealloc];
+#endif
 }
 
 @end

--- a/XMLRPCDefaultEncoder.m
+++ b/XMLRPCDefaultEncoder.m
@@ -78,6 +78,7 @@
 #pragma mark -
 
 - (void)setMethod: (NSString *)method withParameters: (NSArray *)parameters {
+#if ! __has_feature(objc_arc)
     if (myMethod)    {
         [myMethod release];
     }
@@ -97,6 +98,10 @@
     } else {
         myParameters = [parameters retain];
     }
+#else
+	myMethod = method;
+	myParameters = parameters;
+#endif
 }
 
 #pragma mark -
@@ -112,10 +117,12 @@
 #pragma mark -
 
 - (void)dealloc {
+#if ! __has_feature(objc_arc)
     [myMethod release];
     [myParameters release];
     
     [super dealloc];
+#endif
 }
 
 @end
@@ -145,7 +152,7 @@
         return [self encodeArray: object];
     } else if ([object isKindOfClass: [NSDictionary class]]) {
         return [self encodeDictionary: object];
-    } else if (((CFBooleanRef)object == kCFBooleanTrue) || ((CFBooleanRef)object == kCFBooleanFalse)) {
+    } else if (((__bridge_retained CFBooleanRef)object == kCFBooleanTrue) || ((__bridge_retained CFBooleanRef)object == kCFBooleanFalse)) {
         return [self encodeBoolean: (CFBooleanRef)object];
     } else if ([object isKindOfClass: [NSNumber class]]) {
         return [self encodeNumber: object];

--- a/XMLRPCEventBasedParser.m
+++ b/XMLRPCEventBasedParser.m
@@ -50,10 +50,12 @@
 #pragma mark -
 
 - (void)dealloc {
+#if ! __has_feature(objc_arc)
     [myParser release];
     [myParserDelegate release];
     
     [super dealloc];
+#endif
 }
 
 @end

--- a/XMLRPCEventBasedParserDelegate.m
+++ b/XMLRPCEventBasedParserDelegate.m
@@ -49,9 +49,10 @@
 #pragma mark -
 
 - (void)setParent: (XMLRPCEventBasedParserDelegate *)parent {
+#if ! __has_feature(objc_arc)
     [parent retain];
-    
     [myParent release];
+#endif
     
     myParent = parent;
 }
@@ -73,9 +74,10 @@
 #pragma mark -
 
 - (void)setElementKey: (NSString *)elementKey {
+#if ! __has_feature(objc_arc)
     [elementKey retain];
-    
     [myElementKey release];
+#endif
     
     myElementKey = elementKey;
 }
@@ -87,9 +89,10 @@
 #pragma mark -
 
 - (void)setElementValue: (id)elementValue {
+#if ! __has_feature(objc_arc)
     [elementValue retain];
-    
     [myElementValue release];
+#endif
     
     myElementValue = elementValue;
 }
@@ -101,11 +104,13 @@
 #pragma mark -
 
 - (void)dealloc {
+#if ! __has_feature(objc_arc)
     [myChildren release];
     [myElementKey release];
     [myElementValue release];
     
     [super dealloc];
+#endif
 }
 
 @end
@@ -127,9 +132,9 @@
         [myChildren addObject: parserDelegate];
         
         [parser setDelegate: parserDelegate];
-        
+#if ! __has_feature(objc_arc)
         [parserDelegate release];
-        
+#endif
         return;
     }
     
@@ -137,17 +142,17 @@
         NSMutableArray *array = [[NSMutableArray alloc] init];
         
         [self setElementValue: array];
-        
+#if ! __has_feature(objc_arc)
         [array release];
-        
+#endif
         [self setElementType: XMLRPCElementTypeArray];
     } else if ([element isEqualToString: @"struct"]) {
         NSMutableDictionary *dictionary = [[NSMutableDictionary alloc] init];
         
         [self setElementValue: dictionary];
-        
+#if ! __has_feature(objc_arc)
         [dictionary release];
-        
+#endif
         [self setElementType: XMLRPCElementTypeDictionary];
     } else if ([element isEqualToString: @"int"] || [element isEqualToString: @"i4"]) {
         [self setElementType: XMLRPCElementTypeInteger];
@@ -170,49 +175,49 @@
         
         if ((myElementType != XMLRPCElementTypeArray) && ![self isDictionaryElementType: myElementType]) {
             elementValue = [self parseString: myElementValue];
-            
+#if ! __has_feature(objc_arc)
             [myElementValue release];
-            
+#endif
             myElementValue = nil;
         }
         
         switch (myElementType) {
             case XMLRPCElementTypeInteger:
                 myElementValue = [self parseInteger: elementValue];
-                
+#if ! __has_feature(objc_arc)
                 [myElementValue retain];
-                
+#endif
                 break;
             case XMLRPCElementTypeDouble:
                 myElementValue = [self parseDouble: elementValue];
-                
+#if ! __has_feature(objc_arc)
                 [myElementValue retain];
-                
+#endif
                 break;
             case XMLRPCElementTypeBoolean:
                 myElementValue = [self parseBoolean: elementValue];
-                
+#if ! __has_feature(objc_arc)
                 [myElementValue retain];
-                
+#endif
                 break;
             case XMLRPCElementTypeString:
             case XMLRPCElementTypeName:
                 myElementValue = elementValue;
-                
+#if ! __has_feature(objc_arc)
                 [myElementValue retain];
-                
+#endif
                 break;
             case XMLRPCElementTypeDate:
                 myElementValue = [self parseDate: elementValue];
-                
+#if ! __has_feature(objc_arc)
                 [myElementValue retain];
-                
+#endif
                 break;
             case XMLRPCElementTypeData:
                 myElementValue = [self parseData: elementValue];
-                
+#if ! __has_feature(objc_arc)
                 [myElementValue retain];
-                
+#endif
                 break;
             default:
                 break;
@@ -296,9 +301,9 @@
     [dateFormatter setDateFormat: format];
     
     result = [dateFormatter dateFromString: dateString];
-    
+#if ! __has_feature(objc_arc)
     [dateFormatter release];
-    
+#endif
     return result;
 }
 

--- a/XMLRPCRequest.m
+++ b/XMLRPCRequest.m
@@ -13,14 +13,21 @@
             myRequest = [[NSMutableURLRequest alloc] init];
         }
         
-        myXMLEncoder = [encoder retain];
+        myXMLEncoder = encoder;
+#if ! __has_feature(objc_arc)
+        [myXMLEncoder retain];
+#endif
     }
     
     return self;
 }
 
 - (id)initWithURL: (NSURL *)URL {
+#if ! __has_feature(objc_arc)
     return [self initWithURL:URL withEncoder:[[[XMLRPCDefaultEncoder alloc] init] autorelease]];
+#else
+    return [self initWithURL:URL withEncoder:[[XMLRPCDefaultEncoder alloc] init]];
+#endif
 }
 
 #pragma mark -
@@ -53,8 +60,12 @@
     //Copy the old method and parameters to the new encoder.
     NSString *method = [myXMLEncoder method];
     NSArray *parameters = [myXMLEncoder parameters];
+#if ! __has_feature(objc_arc)
     [myXMLEncoder release];
     myXMLEncoder = [encoder retain];
+#else
+    myXMLEncoder = encoder;
+#endif
     [myXMLEncoder setMethod:method withParameters:parameters];
 }
 
@@ -143,10 +154,12 @@
 #pragma mark -
 
 - (void)dealloc {
+#if ! __has_feature(objc_arc)
     [myRequest release];
     [myXMLEncoder release];
     
     [super dealloc];
+#endif
 }
 
 @end

--- a/XMLRPCResponse.h
+++ b/XMLRPCResponse.h
@@ -26,4 +26,8 @@
 
 - (NSString *)body;
 
+#pragma mark -
+
+- (NSString *)description;
+
 @end

--- a/XMLRPCResponse.m
+++ b/XMLRPCResponse.m
@@ -13,17 +13,23 @@
         XMLRPCEventBasedParser *parser = [[XMLRPCEventBasedParser alloc] initWithData: data];
         
         if (!parser) {
+#if ! __has_feature(objc_arc)
             [self release];
-            
+#endif
             return nil;
         }
     
         myBody = [[NSString alloc] initWithData: data encoding: NSUTF8StringEncoding];
-        myObject = [[parser parse] retain];
+        myObject = [parser parse];
+#if ! __has_feature(objc_arc)
+        [myObject retain];
+#endif
         
         isFault = [parser isFault];
         
+#if ! __has_feature(objc_arc)
         [parser release];
+#endif
     }
     
     return self;
@@ -65,11 +71,27 @@
 
 #pragma mark -
 
+- (NSString *)description {
+	NSMutableString	*msg = [NSMutableString stringWithCapacity:128];
+	[msg appendFormat:@"[body=%@", myBody];
+	if (isFault) {
+		[msg appendFormat:@", fault[%@]='%@'", [self faultCode], [self faultString]];
+	} else {
+		[msg appendFormat:@", obj=%@", myObject];
+	}
+	[msg appendString:@"]"];
+	return msg;
+}
+
+#pragma mark -
+
 - (void)dealloc {
+#if ! __has_feature(objc_arc)
     [myBody release];
     [myObject release];
     
     [super dealloc];
+#endif
 }
 
 @end


### PR DESCRIPTION
# Adding ARC Support

The simplest way to support ARC and maintain retain/release support is to make use of the compiler's knowledge of ARC support. This is easily done with something like:

``` objc
#if ! __has_feature(objc_arc)
    return [NSMakeCollectable(temporaryUUIDString) autorelease];
#else
    return (__bridge_transfer NSString*)temporaryUUIDString;
#endif
```

I've simply loaded up the XMLRPC code into my ARC project, and the compiler pointed out all the offending method calls that I needed to correct. I've gone through and simply removed the retain/release methods where necessary, but leaving them in for the non-ARC compiles.

It's been working for me in ARC mode, quite nicely.
