### PR TITLE
async xml parsing + memory leak fixed

### DIFF
--- a/XMLRPCEventBasedParserDelegate.h
+++ b/XMLRPCEventBasedParserDelegate.h
@@ -16,8 +16,13 @@ typedef enum {
 #pragma mark -
 
 @interface XMLRPCEventBasedParserDelegate : NSObject<NSXMLParserDelegate> {
+#if !__has_feature(__objc_arc)
     XMLRPCEventBasedParserDelegate *myParent;
-    NSMutableArray *myChildren;
+#else
+    // without ARC this reference is effectively unretained so don't use strong reference here
+    __unsafe_unretained XMLRPCEventBasedParserDelegate *myParent;
+#endif
+    NSMutableSet *myChildren;
     XMLRPCElementType myElementType;
     NSString *myElementKey;
     id myElementValue;

--- a/XMLRPCEventBasedParserDelegate.m
+++ b/XMLRPCEventBasedParserDelegate.m
@@ -37,7 +37,7 @@
     self = [super init];
     if (self) {
         myParent = parent;
-        myChildren = [[NSMutableArray alloc] initWithCapacity: 1];
+        myChildren = [[NSMutableSet alloc] initWithCapacity: 1];
         myElementType = XMLRPCElementTypeString;
         myElementKey = nil;
         myElementValue = [[NSMutableString alloc] init];
@@ -228,6 +228,12 @@
         }
         
         [parser setDelegate: myParent];
+
+        if (myParent) {
+            [myParent->myChildren removeObject:self];
+            // set it to nil explicitly since it's not __weak but __unsafe_unretained
+            myParent = nil;
+        }
     }
 }
 


### PR DESCRIPTION
- Async XML parsing (doesn't freeze UI on huge XML responses)
- Fixed memory leak under ARC, improvement in parser delegate handling

If you don't like async xml feature, I can make new pull request only with memory leak fix.
